### PR TITLE
Update cloudwatchlogs_lambda.js

### DIFF
--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -62,7 +62,7 @@ exports.handler = function(event, context) {
 				var group=awslogsData.logGroup;
 				var rs = re.exec(val.message);
 
-				val.requestID = (rs!==null) ? rs[1] : null;
+				val.requestID = (rs!==null) ? rs[0] : null;
 				val.logStream = stream;
 				val.logGroup = group;
 				req.end(JSON.stringify(val));


### PR DESCRIPTION
RecordID typically appears only once in a message. The regex is correct but the value needs to be pulled from index 0. Pulling from index one will alway lead to null output for requestID.
